### PR TITLE
Upgrades `setup-go` to v5

### DIFF
--- a/data/reusables/actions/action-setup-go.md
+++ b/data/reusables/actions/action-setup-go.md
@@ -1,1 +1,1 @@
-actions/setup-go@{% ifversion actions-setup-go-default-cache-enabled %}v4{% else %}v3{% endif %}
+actions/setup-go@{% ifversion actions-setup-go-default-cache-enabled %}v5{% else %}v3{% endif %}


### PR DESCRIPTION
Version 5 is the most current. This updates the reusable data to reference v5 which does not emit warnings about an outdated Node.js version (which v4 does).

### Why:

Closes: https://github.com/github/docs/issues/32684

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This updates the reusable data that is used throughout Go related docs on GitHub.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
